### PR TITLE
uncorrectable codewords bugfix

### DIFF
--- a/scrape_cm1000.py
+++ b/scrape_cm1000.py
@@ -241,7 +241,7 @@ def set_ds_metrics(metrics: dict):
                 channel=key,
                 channel_type=channel_type,
                 direction=direction
-            ).set(float(val['correctable_codewords']))
+            ).set(float(val['uncorrectable_codewords']))
 
 
 def set_us_metrics(metrics: dict):


### PR DESCRIPTION
Noticed that the uncorrectable codewords were showing the same values as correctable codewords, I believe it is simply a typo and this should fix it.